### PR TITLE
Switch log level to debug instead of warning, when a column can not b…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Version 1.0.0-alpha35
+
+## Bugfixes
+
+* None
+
+## Features
+
+* Switch log level to debug instead of warning, when a column can not be mapped to a attribute directly
+
 # Version 1.0.0-alpha34
 
 ## Bugfixes

--- a/src/Observers/AttributeObserverTrait.php
+++ b/src/Observers/AttributeObserverTrait.php
@@ -96,7 +96,7 @@ trait AttributeObserverTrait
             if (!isset($attributes[$attributeCode = $headers[$key]])) {
                 // log a message in debug mode
                 if ($this->isDebugMode()) {
-                    $this->getSystemLogger()->warning(
+                    $this->getSystemLogger()->debug(
                         sprintf(
                             'Can\'t find attribute with attribute code %s in file %s on line %d',
                             $attributeCode,


### PR DESCRIPTION
…e mapped to a attribute directly