### PR TITLE
FIX: Update category path handling in order to use store view specific slugs

### DIFF
--- a/src/Assembler/CategoryAssembler.php
+++ b/src/Assembler/CategoryAssembler.php
@@ -103,4 +103,46 @@ class CategoryAssembler
         // return array with the categories
         return $categories;
     }
+
+
+    /**
+     * Returns an array with the available categories and their
+     * resolved path as keys by store view id.
+     *
+     * @param int $storeViewId
+     * @return array The array with the categories
+     */
+    public function getCategoriesWithResolvedPathByStoreView($storeViewId)
+    {
+        // prepare the categories
+        $categories = array();
+
+        // create the array with the resolved category path as keys
+        foreach ($this->categoryRepository->findAllByStoreView($storeViewId) as $category) {
+            // expload the entity IDs from the category path
+            $entityIds = explode('/', $category[MemberNames::PATH]);
+
+            // cut-off the root category
+            array_shift($entityIds);
+
+            // continue with the next category if no entity IDs are available
+            if (sizeof($entityIds) === 0) {
+                continue;
+            }
+
+            // initialize the array for the path elements
+            $path = array();
+            foreach ($entityIds as $entityId) {
+                $cat = $this->categoryVarcharRepository->findByEntityId($entityId);
+                $path[] = $cat[MemberNames::VALUE];
+            }
+
+            // append the catogory with the string path as key
+            $categories[implode('/', $path)] = $category;
+        }
+
+        // return array with the categories
+        return $categories;
+    }
+
 }

--- a/src/Repositories/CategoryRepository.php
+++ b/src/Repositories/CategoryRepository.php
@@ -49,6 +49,13 @@ class CategoryRepository extends AbstractRepository implements CategoryRepositor
     protected $rootCategoriesStmt;
 
     /**
+     * The statement to load categories by store view id.
+     *
+     * @var \PDOStatement
+     */
+    protected $categoriesByStoreViewStmt;
+
+    /**
      * Initializes the repository's prepared statements.
      *
      * @return void
@@ -64,6 +71,8 @@ class CategoryRepository extends AbstractRepository implements CategoryRepositor
             $this->getConnection()->prepare($this->getUtilityClass()->find($utilityClassName::CATEGORIES));
         $this->rootCategoriesStmt =
             $this->getConnection()->prepare($this->getUtilityClass()->find($utilityClassName::ROOT_CATEGORIES));
+        $this->categoriesByStoreViewStmt =
+            $this->getConnection()->prepare($this->getUtilityClass()->find($utilityClassName::CATEGORIES_BY_STORE_VIEW));
     }
 
     /**
@@ -76,6 +85,21 @@ class CategoryRepository extends AbstractRepository implements CategoryRepositor
         // try to load the categories
         $this->categoriesStmt->execute();
         return $this->categoriesStmt->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Return's an array with all available categories by store view id
+     *
+     * @param int $storeViewId
+     * @return array The available categories
+     */
+    public function findAllByStoreView($storeViewId)
+    {
+        // try to load the categories
+        $this->categoriesByStoreViewStmt->execute(array(
+            MemberNames::STORE_ID => $storeViewId
+        ));
+        return $this->categoriesByStoreViewStmt->fetchAll(\PDO::FETCH_ASSOC);
     }
 
     /**

--- a/src/Repositories/CategoryRepositoryInterface.php
+++ b/src/Repositories/CategoryRepositoryInterface.php
@@ -40,6 +40,14 @@ interface CategoryRepositoryInterface extends RepositoryInterface
     public function findAll();
 
     /**
+     * Return's an array with all available categories by store view id
+     *
+     * @param int $storeViewId
+     * @return array The available categories
+     */
+    public function findAllByStoreView($storeViewId);
+
+    /**
      * Return's an array with the root categories with the store code as key.
      *
      * @return array The root categories

--- a/src/Services/ImportProcessor.php
+++ b/src/Services/ImportProcessor.php
@@ -1010,7 +1010,17 @@ class ImportProcessor implements ImportProcessorInterface
         $globalData[RegistryKeys::EAV_USER_DEFINED_ATTRIBUTES] = $eavUserDefinedAttributes;
 
         // initialize the array with the avaliable categories
+        // this property should be replaced by CATEGORIES_PER_STORE_VIEW
+        // for compatibility reasons it will be still initialized here
         $globalData[RegistryKeys::CATEGORIES] = $this->categoryAssembler->getCategoriesWithResolvedPath();
+
+        // initialize categories per store view
+        $globalData[RegistryKeys::CATEGORIES_PER_STORE_VIEW] = array();
+        foreach ($globalData[RegistryKeys::STORES] as $storeView) {
+            $storeViewCode = $storeView[MemberNames::CODE];
+            $storeViewId = $storeView[MemberNames::STORE_ID];
+            $globalData[RegistryKeys::CATEGORIES_PER_STORE_VIEW][$storeViewCode] = $this->categoryAssembler->getCategoriesWithResolvedPathByStoreView($storeViewId);
+        }
 
         // return the array
         return $globalData;

--- a/src/Utils/RegistryKeys.php
+++ b/src/Utils/RegistryKeys.php
@@ -165,8 +165,16 @@ class RegistryKeys
      * Key for the registry entry containing the categories.
      *
      * @var string
+     * @deprecated use CATEGORIES_PER_STORE_VIEW
      */
     const CATEGORIES = 'categories';
+
+    /**
+     * Key for the registry entry containing the categories.
+     *
+     * @var string
+     */
+    const CATEGORIES_PER_STORE_VIEW = 'categories_per_store_view';
 
     /**
      * Key for the registry entry containing the root categories.

--- a/src/Utils/SqlStatements.php
+++ b/src/Utils/SqlStatements.php
@@ -11,8 +11,8 @@
  *
  * PHP version 5
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2016 TechDivision GmbH <info@techdivision.com>
+ * @author    Tim Wagner <t.wagner:techdivision.com>
+ * @copyright 2016 TechDivision GmbH <info:techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import
  * @link      http://www.techdivision.com
@@ -23,8 +23,8 @@ namespace TechDivision\Import\Utils;
 /**
  * Utility class with the SQL statements to use.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2016 TechDivision GmbH <info@techdivision.com>
+ * @author    Tim Wagner <t.wagner:techdivision.com>
+ * @copyright 2016 TechDivision GmbH <info:techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import
  * @link      http://www.techdivision.com
@@ -38,6 +38,13 @@ class SqlStatements extends AbstractSqlStatements
      * @var string
      */
     const CATEGORIES = 'categories';
+
+    /**
+     * The SQL statement to load all categories by store view id.
+     *
+     * @var string
+     */
+    const CATEGORIES_BY_STORE_VIEW = 'categories_by_store_view';
 
     /**
      * The SQL statement to load the root categories.
@@ -342,13 +349,79 @@ class SqlStatements extends AbstractSqlStatements
                         AND t2.store_id = 0
                         AND t2.entity_id = t0.entity_id) AS is_anchor
                FROM catalog_category_entity AS t0',
-        SqlStatements::ROOT_CATEGORIES =>
-            'SELECT t2.code, t0.*
-               FROM catalog_category_entity t0
-         INNER JOIN store_group t1
-                 ON t1.root_category_id = t0.entity_id
-         INNER JOIN store t2
-                 ON t2.group_id = t1.group_id',
+        SqlStatements::CATEGORIES_BY_STORE_VIEW =>
+            'SELECT 
+                t0.*, 
+                IF(name_store.value_id > 0, name_store.value, name_default.value) AS name,
+                IF(url_key_store.value_id > 0, url_key_store.value, url_key_default.value) AS url_key,
+                IF(url_path_store.value_id > 0, url_path_store.value, url_path_default.value) AS url_path,
+                IF(is_anchor_store.value_id > 0, is_anchor_store.value, is_anchor_default.value) AS is_anchor
+                
+                FROM catalog_category_entity AS t0
+                
+                LEFT JOIN catalog_category_entity_varchar AS name_store
+                  ON name_store.attribute_id = (
+                    SELECT attribute_id FROM eav_attribute 
+                    WHERE attribute_code = \'name\' AND entity_type_id = 3
+                  )
+                  AND name_store.store_id = :store_id
+                  AND name_store.row_id = t0.row_id 
+                  
+                LEFT JOIN catalog_category_entity_varchar AS name_default
+                  ON name_default.attribute_id = (
+                    SELECT attribute_id FROM eav_attribute 
+                    WHERE attribute_code = \'name\' AND entity_type_id = 3
+                  )
+                  AND name_default.store_id = 0
+                  AND name_default.row_id = t0.row_id 
+                  
+                LEFT JOIN catalog_category_entity_varchar AS url_key_store
+                  ON url_key_store.attribute_id = (
+                    SELECT attribute_id FROM eav_attribute 
+                    WHERE attribute_code = \'url_key\' AND entity_type_id = 3
+                  )
+                  AND url_key_store.store_id = :store_id
+                  AND url_key_store.row_id = t0.row_id 
+                  
+                LEFT JOIN catalog_category_entity_varchar AS url_key_default
+                  ON url_key_default.attribute_id = (
+                    SELECT attribute_id FROM eav_attribute 
+                    WHERE attribute_code = \'url_key\' AND entity_type_id = 3
+                  )
+                  AND url_key_default.store_id = 0
+                  AND url_key_default.row_id = t0.row_id 
+                  
+                LEFT JOIN catalog_category_entity_varchar AS url_path_store
+                  ON url_path_store.attribute_id = (
+                    SELECT attribute_id FROM eav_attribute 
+                    WHERE attribute_code = \'url_path\' AND entity_type_id = 3
+                  )
+                  AND url_path_store.store_id = :store_id
+                  AND url_path_store.row_id = t0.row_id 
+                  
+                LEFT JOIN catalog_category_entity_varchar AS url_path_default
+                  ON url_path_default.attribute_id = (
+                    SELECT attribute_id FROM eav_attribute 
+                    WHERE attribute_code = \'url_path\' AND entity_type_id = 3
+                  )
+                  AND url_path_default.store_id = 0
+                  AND url_path_default.row_id = t0.row_id 
+                  
+                LEFT JOIN catalog_category_entity_int AS is_anchor_store
+                  ON is_anchor_store.attribute_id = (
+                    SELECT attribute_id FROM eav_attribute 
+                    WHERE attribute_code = \'is_anchor\' AND entity_type_id = 3
+                  )
+                  AND is_anchor_store.store_id = :store_id
+                  AND is_anchor_store.row_id = t0.row_id 
+                  
+                LEFT JOIN catalog_category_entity_int AS is_anchor_default
+                  ON is_anchor_default.attribute_id = (
+                    SELECT attribute_id FROM eav_attribute 
+                    WHERE attribute_code = \'is_anchor\' AND entity_type_id = 3
+                  )
+                  AND is_anchor_default.store_id = 0
+                  AND is_anchor_default.row_id = t0.row_id',
         SqlStatements::ROOT_CATEGORIES =>
             'SELECT t2.code, t0.*
                FROM catalog_category_entity t0


### PR DESCRIPTION
Current implementation of techdivision/import-product-url-rewrite does care about store view specific url slugs in categories. For this fix we need changes in this library.