### PR TITLE
Extract dev autoloading to declutter classmap in prod

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,13 @@
         "psr-4": {
             "TechDivision\\Import\\": [
                 "src/",
-                "symfony/",
+                "symfony/"
+            ]
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "TechDivision\\Import\\": [
                 "tests/unit/"
             ]
         }


### PR DESCRIPTION
I think we should do this in all techdivision/* repos