### PR TITLE
Fix ICONV_IMPL check

### DIFF
--- a/src/Utils/Filter/ConvertLiteral.php
+++ b/src/Utils/Filter/ConvertLiteral.php
@@ -443,7 +443,7 @@ class ConvertLiteral implements FilterInterface
     public function filter($string)
     {
         $string = strtr($string, $this->getConvertTable());
-        return '"libiconv"' == ICONV_IMPL ? iconv(
+        return 'libiconv' == trim(ICONV_IMPL, '"'."'") ? iconv(
             'UTF-8',
             'ascii//ignore//translit',
             $string


### PR DESCRIPTION
In my case it is not `"libiconv"` but `libiconv`.
Nonetheless for BC, this fix trims quotes before compare so any case will work.