### PR TITLE
PAC-96 - Add option to override images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Version 16.2.0
+
+## Bugfixes
+
+* None
+
+## Features
+
+* Add #PAC-96
+
 # Version 16.1.0
 
 ## Bugfixes

--- a/src/Subjects/FileUploadTrait.php
+++ b/src/Subjects/FileUploadTrait.php
@@ -61,6 +61,35 @@ trait FileUploadTrait
     protected $copyImages = false;
 
     /**
+     * Whether or not to override images with the same name.
+     *
+     * @var bool
+     */
+    protected $overrideImages = false;
+
+    /**
+     * Sets whether or not to override images with the same name.
+     *
+     * @param $overrideImages
+     *
+     * @return void
+     */
+    public function setOverrideImages($overrideImages)
+    {
+        $this->overrideImages = $overrideImages;
+    }
+
+    /**
+     * Returns whether or not we should override images with the same name.
+     *
+     * @return bool
+     */
+    public function shouldOverride()
+    {
+        return $this->overrideImages;
+    }
+
+    /**
      * Set's the flag to copy the images or not.
      *
      * @param boolean $copyImages The flag
@@ -214,8 +243,8 @@ trait FileUploadTrait
         // load the file information
         $fileInfo = pathinfo($targetFilename);
 
-        // query whether or not, the file exists
-        if ($this->getFilesystemAdapter()->isFile($targetFilename)) {
+        // query whether or not the file exists and if we should override it
+        if ($this->getFilesystemAdapter()->isFile($targetFilename) && $this->shouldOverride() === false) {
             // initialize the index and the basename
             $index = 1;
             $baseName = $fileInfo['filename'] . '.' . $fileInfo['extension'];

--- a/src/Subjects/FileUploadTrait.php
+++ b/src/Subjects/FileUploadTrait.php
@@ -62,29 +62,32 @@ trait FileUploadTrait
 
     /**
      * Whether or not to override images with the same name.
+     * TODO: Refactor to make protected
      *
      * @var boolean
      */
-    protected $overrideImages = false;
+    private $overrideImages = false;
 
     /**
      * Sets whether or not to override images with the same name.
+     * TODO: Refactor to make public
      *
      * @param boolean $overrideImages Whether or not to override images
      *
      * @return void
      */
-    public function setOverrideImages($overrideImages)
+    private function setOverrideImages($overrideImages)
     {
         $this->overrideImages = $overrideImages;
     }
 
     /**
      * Returns whether or not we should override images with the same name.
+     * TODO: Refactor to make public or protected
      *
      * @return bool
      */
-    public function shouldOverride()
+    private function shouldOverride()
     {
         return $this->overrideImages;
     }

--- a/src/Subjects/FileUploadTrait.php
+++ b/src/Subjects/FileUploadTrait.php
@@ -63,14 +63,14 @@ trait FileUploadTrait
     /**
      * Whether or not to override images with the same name.
      *
-     * @var bool
+     * @var boolean
      */
     protected $overrideImages = false;
 
     /**
      * Sets whether or not to override images with the same name.
      *
-     * @param $overrideImages
+     * @param boolean $overrideImages Whether or not to override images
      *
      * @return void
      */

--- a/src/Utils/FileUploadConfigurationKeys.php
+++ b/src/Utils/FileUploadConfigurationKeys.php
@@ -54,4 +54,11 @@ class FileUploadConfigurationKeys
      * @var string
      */
     const COPY_IMAGES = 'copy-images';
+
+    /**
+     * Name of the column 'override-images'.
+     *
+     * @var string
+     */
+    const OVERRIDE_IMAGES = 'override-images';
 }

--- a/src/Utils/FileUploadConfigurationKeys.php
+++ b/src/Utils/FileUploadConfigurationKeys.php
@@ -54,11 +54,4 @@ class FileUploadConfigurationKeys
      * @var string
      */
     const COPY_IMAGES = 'copy-images';
-
-    /**
-     * Name of the column 'override-images'.
-     *
-     * @var string
-     */
-    const OVERRIDE_IMAGES = 'override-images';
 }


### PR DESCRIPTION
Adds new subject option 'override-images' with boolean values true and false (default: false). If this option is enabed, already existing images with the same filename will be replaced by the new image. Example: 'image.png' will be replaced instead of creating a new 'image_0.png'.