### PR TITLE
Add NativeMailerHandler from Monolog

### DIFF
--- a/src/Loggers/ErrorLogHandlerFactory.php
+++ b/src/Loggers/ErrorLogHandlerFactory.php
@@ -29,8 +29,8 @@ use TechDivision\Import\Configuration\Logger\HandlerConfigurationInterface;
 /**
  * Error Log Handler factory implementation.
  *
- * @author    Martin Eisenführer <m.eisenfuehrer@techdivision.com>
- * @copyright 2020 TechDivision GmbH <info@techdivision.com>
+ * @author    Tim Wagner <t.wagner@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import
  * @link      http://www.techdivision.com

--- a/src/Loggers/GenericLogHandlerFactory.php
+++ b/src/Loggers/GenericLogHandlerFactory.php
@@ -11,8 +11,8 @@
  *
  * PHP version 5
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2019 TechDivision GmbH <info@techdivision.com>
+ * @author    Martin Eisenführer <m.eisenfuehrer@techdivision.com>
+ * @copyright 2020 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import
  * @link      http://www.techdivision.com

--- a/src/Loggers/GenericLogHandlerFactory.php
+++ b/src/Loggers/GenericLogHandlerFactory.php
@@ -54,8 +54,8 @@ class GenericLogHandlerFactory implements HandlerFactoryInterface
     /**
      * Initialize the processor with the actual configuration instance
      *
-     * @param \TechDivision\Import\Configuration\ConfigurationInterface $configuration     The actual configuration instance
-     * @param string                                                  $handlerClassName Classname for monolog Logger handler
+     * @param ConfigurationInterface $configuration    the actual configuration instance
+     * @param string                 $handlerClassName Classname for monolog Logger handler
      */
     public function __construct(ConfigurationInterface $configuration, $handlerClassName)
     {

--- a/src/Loggers/GenericLogHandlerFactory.php
+++ b/src/Loggers/GenericLogHandlerFactory.php
@@ -54,8 +54,8 @@ class GenericLogHandlerFactory implements HandlerFactoryInterface
     /**
      * Initialize the processor with the actual configuration instance
      *
-     * @param \TechDivision\Import\Configuration\ConfigurationInterface $configuration The actual configuration instance
-     * @param string $handlerClassName
+     * @param \TechDivision\Import\Configuration\ConfigurationInterface $configuration     The actual configuration instance
+     * @param string                                                  $handlerClassName Classname for monolog Logger handler
      */
     public function __construct(ConfigurationInterface $configuration, $handlerClassName)
     {

--- a/src/Loggers/GenericLogHandlerFactory.php
+++ b/src/Loggers/GenericLogHandlerFactory.php
@@ -20,7 +20,6 @@
 
 namespace TechDivision\Import\Loggers;
 
-use Monolog\Handler\ErrorLogHandler;
 use TechDivision\Import\Utils\ConfigurationUtil;
 use TechDivision\Import\Utils\ConfigurationKeys;
 use TechDivision\Import\Configuration\ConfigurationInterface;
@@ -29,15 +28,13 @@ use TechDivision\Import\Configuration\Logger\HandlerConfigurationInterface;
 /**
  * Error Log Handler factory implementation.
  *
- * @author    Martin Eisenführer <m.eisenfuehrer@techdivision.com>
- * @copyright 2020 TechDivision GmbH <info@techdivision.com>
+ * @author    Tim Wagner <t.wagner@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import
  * @link      http://www.techdivision.com
- *
- * @deprecated use GenericLogHandlerFactory
  */
-class ErrorLogHandlerFactory implements HandlerFactoryInterface
+class GenericLogHandlerFactory implements HandlerFactoryInterface
 {
 
     /**
@@ -48,13 +45,22 @@ class ErrorLogHandlerFactory implements HandlerFactoryInterface
     protected $defaultLogLevel;
 
     /**
+     * The log level to use.
+     *
+     * @var string
+     */
+    protected $handlerClassName;
+
+    /**
      * Initialize the processor with the actual configuration instance
      *
      * @param \TechDivision\Import\Configuration\ConfigurationInterface $configuration The actual configuration instance
+     * @param string $handlerClassName
      */
-    public function __construct(ConfigurationInterface $configuration)
+    public function __construct(ConfigurationInterface $configuration, $handlerClassName)
     {
         $this->defaultLogLevel = $configuration->getLogLevel();
+        $this->handlerClassName = $handlerClassName;
     }
 
     /**
@@ -76,7 +82,7 @@ class ErrorLogHandlerFactory implements HandlerFactoryInterface
         }
 
         // create and return the handler instance
-        $reflectionClass = new \ReflectionClass(ErrorLogHandler::class);
+        $reflectionClass = new \ReflectionClass($this->handlerClassName);
         return $reflectionClass->newInstanceArgs(ConfigurationUtil::prepareConstructorArgs($reflectionClass, $params));
     }
 }

--- a/src/Loggers/GenericLogHandlerFactory.php
+++ b/src/Loggers/GenericLogHandlerFactory.php
@@ -28,8 +28,8 @@ use TechDivision\Import\Configuration\Logger\HandlerConfigurationInterface;
 /**
  * Error Log Handler factory implementation.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2019 TechDivision GmbH <info@techdivision.com>
+ * @author    Martin Eisenführer <m.eisenfuehrer@techdivision.com>
+ * @copyright 2020 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import
  * @link      http://www.techdivision.com

--- a/symfony/Resources/config/services.xml
+++ b/symfony/Resources/config/services.xml
@@ -31,8 +31,13 @@
             <argument type="service" id="service_container"/>
             <argument type="service" id="import.logger.factory.monolog.handler"/>
         </service>
-        <service id="import.logger.factory.handler.error.log" class="TechDivision\Import\Loggers\ErrorLogHandlerFactory" shared="false">
+        <service id="import.logger.factory.handler.native.mail.log" class="TechDivision\Import\Loggers\GenericLogHandlerFactory" shared="false">
             <argument type="service" id="configuration"/>
+            <argument type="string">Monolog\Handler\NativeMailerHandler</argument>
+        </service>
+        <service id="import.logger.factory.handler.error.log" class="TechDivision\Import\Loggers\GenericLogHandlerFactory" shared="false">
+            <argument type="service" id="configuration"/>
+            <argument type="string">Monolog\Handler\ErrorLogHandler</argument>
         </service>
         <service id="import.logger.factory.handler.swift" class="TechDivision\Import\Loggers\SwiftMailerHandlerFactory" shared="false">
             <argument type="service" id="service_container"/>


### PR DESCRIPTION
Add handler for NativeMailerLog from Issue #191.
Example to use in your own loggers.json handler entry point 
```
{
    "id": "import.logger.factory.handler.native.mail.log",
    "formatter": {
        "id": "import.logger.factory.formatter.line",
        "params": {
            "format": "[%datetime%] %channel%.%level_name%: %message% %context% %extra%",
            "date-format": "Y-m-d H:i:s",
            "allow-inline-line-breaks": true,
            "ignore-empty-context-and-extra": true
        }
    },
    "params": {
        "to": [
            "tw@techdivision.com"
        ],
        "subject": "Something Went Wrong",
        "from": "pacemaker@techdivision.com",
        "level": "error",
        "bubble": true,
        "maxColumnWidth": 500
    }
}
```