### PR TITLE
Remove EAV relation in add-update operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add second log handler to log to console also
 * Adjust log messages to log only message with log level `notice` to console
 * Add #PAC-89: Add debug email command + DebugSendPlugin
+* Add #PAC-57: Deleting dedicated attribute values via import by setting a configurable value
 
 # Version 16.5.3
 

--- a/etc/configuration.json
+++ b/etc/configuration.json
@@ -13,5 +13,6 @@
     "general": [],
     "ce": [],
     "ee": []
-  }
+  },
+  "empty-attribute-value-constant": "__EMPTY__VALUE__"
 }

--- a/src/Observers/AttributeObserverTrait.php
+++ b/src/Observers/AttributeObserverTrait.php
@@ -20,6 +20,7 @@
 
 namespace TechDivision\Import\Observers;
 
+use TechDivision\Import\Utils\InputOptionKeysInterface;
 use TechDivision\Import\Utils\LoggerKeys;
 use TechDivision\Import\Utils\MemberNames;
 use TechDivision\Import\Utils\StoreViewCodes;
@@ -123,6 +124,16 @@ trait AttributeObserverTrait
     }
 
     /**
+     * Get empty attribute value constant from global konfiguration
+     *
+     * @return string
+     */
+    private function getEmptyAttributeValueConstant()
+    {
+        return $this->getSubject()->getConfiguration()->getConfiguration()->getEmptyAttributeValueConstant();
+    }
+
+    /**
      * Remove all the empty values from the row and return the cleared row.
      *
      * @return array The cleared row
@@ -162,8 +173,15 @@ trait AttributeObserverTrait
             }
         }
 
+        $emptyValueDefinition = $this->getEmptyAttributeValueConstant();
+        // load the header keys
+        $headers = in_array($emptyValueDefinition, $this->row, true) ? array_flip($this->getHeaders()) : [];
         // remove all the empty values from the row, expected the columns has to be cleaned-up
         foreach ($this->row as $key => $value) {
+            if ($value === $emptyValueDefinition) {
+                $this->cleanUpEmptyColumnKeys[$headers[$key]] = $key;
+                $this->row[$key] = '';
+            }
             // query whether or not the value is empty AND the column has NOT to be cleaned-up
             if (($value === null || $value === '') &&
                 in_array($key, $this->cleanUpEmptyColumnKeys) === false &&

--- a/src/Observers/GenericValidatorObserver.php
+++ b/src/Observers/GenericValidatorObserver.php
@@ -78,14 +78,14 @@ class GenericValidatorObserver extends AbstractObserver
     /**
      * Process the observer's business logic.
      *
-     * @return array The processed row
+     * @return void
      */
     protected function process()
     {
 
         // load the available header names
         $headerNames = array_keys($this->getHeaders());
-
+        $emptyValueDefinition = $this->getEmptyAttributeValueConstant();
         // iterate over the custom validations
         foreach ($headerNames as $headerName) {
             // map the header name to the attribute code, if an mapping is available
@@ -97,6 +97,10 @@ class GenericValidatorObserver extends AbstractObserver
             // invoke the registered callbacks
             foreach ($callbacks as $callback) {
                 try {
+                    // query whether or not to cleanup complete attribute
+                    if ($attributeValue === $emptyValueDefinition) {
+                        continue;
+                    }
                     $callback->handle($attributeCode, $attributeValue);
                 } catch (\InvalidArgumentException $iea) {
                     // add the the validation result to the status
@@ -114,6 +118,14 @@ class GenericValidatorObserver extends AbstractObserver
                 }
             }
         }
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmptyAttributeValueConstant()
+    {
+        return $this->getSubject()->getConfiguration()->getConfiguration()->getEmptyAttributeValueConstant();
     }
 
     /**

--- a/src/Utils/InputOptionKeysInterface.php
+++ b/src/Utils/InputOptionKeysInterface.php
@@ -229,6 +229,13 @@ interface InputOptionKeysInterface extends \ArrayAccess
     const RENDER_DEBUG_SERIALS = 'render-debug-serials';
 
     /**
+     * The input option key for the empty value in attribute option import
+     *
+     * @var string
+     */
+    const EMPTY_ATTRIBUTE_VALUE_CONSTANT = 'empty-attribute-value-constant';
+
+    /**
      * Query whether or not the passed input option is valid.
      *
      * @param string $inputOption The input option to query for

--- a/tests/unit/Observers/AbstractAttributeObserverTest.php
+++ b/tests/unit/Observers/AbstractAttributeObserverTest.php
@@ -101,10 +101,17 @@ class AbstractAttributeObserverTest extends TestCase
         $mockSubjectConfiguration = $this->getMockBuilder('TechDivision\Import\Configuration\SubjectConfigurationInterface')
                                          ->setMethods(get_class_methods('TechDivision\Import\Configuration\SubjectConfigurationInterface'))
                                          ->getMock();
+
         $mockSubjectConfiguration->expects($this->once())
                                  ->method('hasParam')
                                  ->with(ConfigurationKeys::CLEAN_UP_EMPTY_COLUMNS)
                                  ->willReturn(false);
+
+        // mock a jms configuration
+        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\Jms\Configuration');
+        $mockSubjectConfiguration->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn($mockJmsConfiguration);
 
         // mock a subject
         $mockSubject = $this->getMockBuilder('TechDivision\Import\Observers\EntitySubjectImpl')
@@ -119,7 +126,7 @@ class AbstractAttributeObserverTest extends TestCase
         $mockSubject->expects($this->once())
                     ->method('appendExceptionSuffix')
                     ->willReturnArgument(0);
-        $mockSubject->expects($this->once())
+        $mockSubject->expects($this->atLeastOnce())
                     ->method('getConfiguration')
                     ->willReturn($mockSubjectConfiguration);
         $mockSubject->expects($this->once())
@@ -205,6 +212,12 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->with(ConfigurationKeys::CLEAN_UP_EMPTY_COLUMNS)
                                  ->willReturn(false);
 
+        // mock a jms configuration
+        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\Jms\Configuration');
+        $mockSubjectConfiguration->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn($mockJmsConfiguration);
+
         // mock a subject
         $mockSubject = $this->getMockBuilder('TechDivision\Import\Observers\EntitySubjectImpl')
                             ->setMethods(get_class_methods('TechDivision\Import\Observers\EntitySubjectImpl'))
@@ -212,7 +225,7 @@ class AbstractAttributeObserverTest extends TestCase
         $mockSubject->expects($this->exactly(2))
                     ->method('appendExceptionSuffix')
                     ->willReturnArgument(0);
-        $mockSubject->expects($this->once())
+        $mockSubject->expects($this->atLeastOnce())
                     ->method('getConfiguration')
                     ->willReturn($mockSubjectConfiguration);
         $mockSubject->expects($this->exactly(2))
@@ -308,6 +321,12 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->with(ConfigurationKeys::CLEAN_UP_EMPTY_COLUMNS)
                                  ->willReturn(false);
 
+        // mock a jms configuration
+        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\Jms\Configuration');
+        $mockSubjectConfiguration->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn($mockJmsConfiguration);
+
         // mock a subject
         $mockSubject = $this->getMockBuilder('TechDivision\Import\Observers\EntitySubjectImpl')
                             ->setMethods(get_class_methods('TechDivision\Import\Observers\EntitySubjectImpl'))
@@ -315,7 +334,7 @@ class AbstractAttributeObserverTest extends TestCase
         $mockSubject->expects($this->once())
                     ->method('appendExceptionSuffix')
                     ->willReturnArgument(0);
-        $mockSubject->expects($this->once())
+        $mockSubject->expects($this->atLeastOnce())
                     ->method('getConfiguration')
                     ->willReturn($mockSubjectConfiguration);
         $mockSubject->expects($this->once())
@@ -404,11 +423,22 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->with(ConfigurationKeys::CLEAN_UP_EMPTY_COLUMNS)
                                  ->willReturn(false);
 
+        // mock a jms configuration
+        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\Jms\Configuration');
+
+        $mockJmsConfiguration->expects($this->once())
+            ->method('getEmptyAttributeValueConstant')
+            ->willReturn('FooBar');
+
+        $mockSubjectConfiguration->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn($mockJmsConfiguration);
+
         // mock a subject
         $mockSubject = $this->getMockBuilder('TechDivision\Import\Observers\EntitySubjectImpl')
                             ->setMethods(get_class_methods('TechDivision\Import\Observers\EntitySubjectImpl'))
                             ->getMock();
-        $mockSubject->expects($this->once())
+        $mockSubject->expects($this->atLeastOnce())
                     ->method('getConfiguration')
                     ->willReturn($mockSubjectConfiguration);
         $mockSubject->expects($this->never())
@@ -496,11 +526,17 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->with(ConfigurationKeys::CLEAN_UP_EMPTY_COLUMNS)
                                  ->willReturn(false);
 
+        // mock a jms configuration
+        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\Jms\Configuration');
+        $mockSubjectConfiguration->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn($mockJmsConfiguration);
+
         // mock a subject
         $mockSubject = $this->getMockBuilder('TechDivision\Import\Observers\EntitySubjectImpl')
                     ->setMethods(get_class_methods('TechDivision\Import\Observers\EntitySubjectImpl'))
                     ->getMock();
-        $mockSubject->expects($this->once())
+        $mockSubject->expects($this->atLeastOnce())
                     ->method('getConfiguration')
                     ->willReturn($mockSubjectConfiguration);
         $mockSubject->expects($this->once())
@@ -584,6 +620,12 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->with(ConfigurationKeys::CLEAN_UP_EMPTY_COLUMNS)
                                  ->willReturn(false);
 
+        // mock a jms configuration
+        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\Jms\Configuration');
+        $mockSubjectConfiguration->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn($mockJmsConfiguration);
+
         // mock a subject
         $mockSubject = $this->getMockBuilder('TechDivision\Import\Observers\EntitySubjectImpl')
                             ->setMethods(get_class_methods('TechDivision\Import\Observers\EntitySubjectImpl'))
@@ -591,7 +633,7 @@ class AbstractAttributeObserverTest extends TestCase
         $mockSubject->expects($this->once())
                     ->method('appendExceptionSuffix')
                     ->willReturnArgument(0);
-        $mockSubject->expects($this->once())
+        $mockSubject->expects($this->atLeastOnce())
                     ->method('getConfiguration')
                     ->willReturn($mockSubjectConfiguration);
         $mockSubject->expects($this->any())
@@ -662,11 +704,17 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->with(ConfigurationKeys::CLEAN_UP_EMPTY_COLUMNS)
                                  ->willReturn(false);
 
+        // mock a jms configuration
+        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\Jms\Configuration');
+        $mockSubjectConfiguration->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn($mockJmsConfiguration);
+
         // mock a subject
         $mockSubject = $this->getMockBuilder('TechDivision\Import\Observers\EntitySubjectImpl')
                             ->setMethods(get_class_methods('TechDivision\Import\Observers\EntitySubjectImpl'))
                             ->getMock();
-        $mockSubject->expects($this->once())
+        $mockSubject->expects($this->atLeastOnce())
                     ->method('getConfiguration')
                     ->willReturn($mockSubjectConfiguration);
         $mockSubject->expects($this->never())

--- a/tests/unit/Observers/AbstractAttributeObserverTest.php
+++ b/tests/unit/Observers/AbstractAttributeObserverTest.php
@@ -108,7 +108,7 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->willReturn(false);
 
         // mock a jms configuration
-        $mockJmsConfiguration = $this->createMock(\TechDivision\Import\Configuration\Jms\Configuration::class);
+        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\ConfigurationInterface');
         $mockSubjectConfiguration->expects($this->once())
             ->method('getConfiguration')
             ->willReturn($mockJmsConfiguration);
@@ -213,7 +213,7 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->willReturn(false);
 
         // mock a jms configuration
-        $mockJmsConfiguration = $this->createMock(\TechDivision\Import\Configuration\Jms\Configuration::class);
+        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\ConfigurationInterface');
         $mockSubjectConfiguration->expects($this->once())
             ->method('getConfiguration')
             ->willReturn($mockJmsConfiguration);
@@ -322,7 +322,7 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->willReturn(false);
 
         // mock a jms configuration
-        $mockJmsConfiguration = $this->createMock(\TechDivision\Import\Configuration\Jms\Configuration::class);
+        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\ConfigurationInterface');
         $mockSubjectConfiguration->expects($this->once())
             ->method('getConfiguration')
             ->willReturn($mockJmsConfiguration);
@@ -424,7 +424,7 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->willReturn(false);
 
         // mock a jms configuration
-        $mockJmsConfiguration = $this->createMock(\TechDivision\Import\Configuration\Jms\Configuration::class);
+        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\ConfigurationInterface');
 
         $mockJmsConfiguration->expects($this->once())
             ->method('getEmptyAttributeValueConstant')
@@ -527,7 +527,7 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->willReturn(false);
 
         // mock a jms configuration
-        $mockJmsConfiguration = $this->createMock(\TechDivision\Import\Configuration\Jms\Configuration::class);
+        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\ConfigurationInterface');
         $mockSubjectConfiguration->expects($this->once())
             ->method('getConfiguration')
             ->willReturn($mockJmsConfiguration);
@@ -621,7 +621,7 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->willReturn(false);
 
         // mock a jms configuration
-        $mockJmsConfiguration = $this->createMock(\TechDivision\Import\Configuration\Jms\Configuration::class);
+        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\ConfigurationInterface');
         $mockSubjectConfiguration->expects($this->once())
             ->method('getConfiguration')
             ->willReturn($mockJmsConfiguration);
@@ -705,7 +705,7 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->willReturn(false);
 
         // mock a jms configuration
-        $mockJmsConfiguration = $this->createMock(\TechDivision\Import\Configuration\Jms\Configuration::class);
+        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\ConfigurationInterface');
         $mockSubjectConfiguration->expects($this->once())
             ->method('getConfiguration')
             ->willReturn($mockJmsConfiguration);

--- a/tests/unit/Observers/AbstractAttributeObserverTest.php
+++ b/tests/unit/Observers/AbstractAttributeObserverTest.php
@@ -108,7 +108,7 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->willReturn(false);
 
         // mock a jms configuration
-        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\Jms\Configuration');
+        $mockJmsConfiguration = $this->createMock(\TechDivision\Import\Configuration\Jms\Configuration::class);
         $mockSubjectConfiguration->expects($this->once())
             ->method('getConfiguration')
             ->willReturn($mockJmsConfiguration);
@@ -213,7 +213,7 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->willReturn(false);
 
         // mock a jms configuration
-        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\Jms\Configuration');
+        $mockJmsConfiguration = $this->createMock(\TechDivision\Import\Configuration\Jms\Configuration::class);
         $mockSubjectConfiguration->expects($this->once())
             ->method('getConfiguration')
             ->willReturn($mockJmsConfiguration);
@@ -322,7 +322,7 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->willReturn(false);
 
         // mock a jms configuration
-        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\Jms\Configuration');
+        $mockJmsConfiguration = $this->createMock(\TechDivision\Import\Configuration\Jms\Configuration::class);
         $mockSubjectConfiguration->expects($this->once())
             ->method('getConfiguration')
             ->willReturn($mockJmsConfiguration);
@@ -424,7 +424,7 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->willReturn(false);
 
         // mock a jms configuration
-        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\Jms\Configuration');
+        $mockJmsConfiguration = $this->createMock(\TechDivision\Import\Configuration\Jms\Configuration::class);
 
         $mockJmsConfiguration->expects($this->once())
             ->method('getEmptyAttributeValueConstant')
@@ -527,7 +527,7 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->willReturn(false);
 
         // mock a jms configuration
-        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\Jms\Configuration');
+        $mockJmsConfiguration = $this->createMock(\TechDivision\Import\Configuration\Jms\Configuration::class);
         $mockSubjectConfiguration->expects($this->once())
             ->method('getConfiguration')
             ->willReturn($mockJmsConfiguration);
@@ -621,7 +621,7 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->willReturn(false);
 
         // mock a jms configuration
-        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\Jms\Configuration');
+        $mockJmsConfiguration = $this->createMock(\TechDivision\Import\Configuration\Jms\Configuration::class);
         $mockSubjectConfiguration->expects($this->once())
             ->method('getConfiguration')
             ->willReturn($mockJmsConfiguration);
@@ -705,7 +705,7 @@ class AbstractAttributeObserverTest extends TestCase
                                  ->willReturn(false);
 
         // mock a jms configuration
-        $mockJmsConfiguration = $this->createMock('TechDivision\Import\Configuration\Jms\Configuration');
+        $mockJmsConfiguration = $this->createMock(\TechDivision\Import\Configuration\Jms\Configuration::class);
         $mockSubjectConfiguration->expects($this->once())
             ->method('getConfiguration')
             ->willReturn($mockJmsConfiguration);


### PR DESCRIPTION
Default attribute value like Magento import with `__EMPTY__VALUE__`