### PR TITLE
add missing dependency to symfony/dependency-injection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "league/event": "^2.2",
         "ramsey/uuid": "^4.2|^4.7",
         "symfony/mailer": "^5.4|^6.4|^7.4",
+        "symfony/dependency-injection": "^7.0|^8.0",
         "laminas/laminas-filter": "^2.31",
         "techdivision/import-dbal": "^2.1",
         "techdivision/import-dbal-collection": "^2.2",


### PR DESCRIPTION
**Version 6 of `symfony/dependency-injection` is incompatible**

e.g. (un)typed class property:
`\TechDivision\Import\DependencyInjection\Loader\XmlFileLoader::$autoRegisterAliasesForSinglyImplementedInterfaces` vs. `\Symfony\Component\DependencyInjection\Loader\FileLoader::$autoRegisterAliasesForSinglyImplementedInterfaces`

---

**:information_source: Info**
`magento/magento2-functional-testing-framework[4.7.1, ..., 4.9.3] require symfony/dependency-injection ^6.4`